### PR TITLE
Incorrect usage of Username in templating

### DIFF
--- a/kuberos.go
+++ b/kuberos.go
@@ -325,7 +325,6 @@ func Template(cfg *api.Config) http.HandlerFunc {
 		c.Clusters = make(map[string]*api.Cluster)
 		c.Contexts = make(map[string]*api.Context)
 		c.AuthInfos[templateUser] = &api.AuthInfo{
-			Username: p.Username,
 			AuthProvider: &api.AuthProviderConfig{
 				Name: templateAuthProvider,
 				Config: map[string]string{


### PR DESCRIPTION
I discovered after some troubleshooting that this adds a line to your config that will confused kubectl (v1.8.5 test). The use of username is for basic auth. 