### PR TITLE
use actual username instead of harcoded string, fixes #17

### DIFF
--- a/kuberos.go
+++ b/kuberos.go
@@ -35,7 +35,6 @@ const (
 	urlParamErrorDescription = "error_description"
 	urlParamErrorURI         = "error_uri"
 
-	templateUser             = "kuberos"
 	templateAuthProvider     = "oidc"
 	templateOIDCClientID     = "client-id"
 	templateOIDCClientSecret = "client-secret"
@@ -339,7 +338,7 @@ func populateUser(cfg *api.Config, p *extractor.OIDCAuthenticationParams) api.Co
 	c.AuthInfos = make(map[string]*api.AuthInfo)
 	c.Clusters = make(map[string]*api.Cluster)
 	c.Contexts = make(map[string]*api.Context)
-	c.AuthInfos[templateUser] = &api.AuthInfo{
+	c.AuthInfos[p.Username] = &api.AuthInfo{
 		AuthProvider: &api.AuthProviderConfig{
 			Name: templateAuthProvider,
 			Config: map[string]string{
@@ -353,7 +352,7 @@ func populateUser(cfg *api.Config, p *extractor.OIDCAuthenticationParams) api.Co
 	}
 	for name, cluster := range cfg.Clusters {
 		c.Clusters[name] = cluster
-		c.Contexts[name] = &api.Context{Cluster: name, AuthInfo: templateUser}
+		c.Contexts[name] = &api.Context{Cluster: name, AuthInfo: p.Username}
 	}
 	return c
 }

--- a/kuberos_test.go
+++ b/kuberos_test.go
@@ -95,6 +95,7 @@ func TestPopulateUser(t *testing.T) {
 				},
 			},
 			params: &extractor.OIDCAuthenticationParams{
+				Username:     "example@example.org",
 				ClientID:     "id",
 				ClientSecret: "secret",
 				IDToken:      "token",
@@ -107,11 +108,11 @@ func TestPopulateUser(t *testing.T) {
 					"b": &api.Cluster{Server: "https://example.net", CertificateAuthorityData: []byte("PAM")},
 				},
 				Contexts: map[string]*api.Context{
-					"a": &api.Context{AuthInfo: templateUser, Cluster: "a"},
-					"b": &api.Context{AuthInfo: templateUser, Cluster: "b"},
+					"a": &api.Context{AuthInfo: "example@example.org", Cluster: "a"},
+					"b": &api.Context{AuthInfo: "example@example.org", Cluster: "b"},
 				},
 				AuthInfos: map[string]*api.AuthInfo{
-					templateUser: &api.AuthInfo{
+					"example@example.org": &api.AuthInfo{
 						AuthProvider: &api.AuthProviderConfig{
 							Name: templateAuthProvider,
 							Config: map[string]string{


### PR DESCRIPTION
since using email as default (https://github.com/negz/kuberos/blob/master/extractor/oidc.go#L22), which often works very well, also use it in the kubecft template handler.

fixes #17