### PR TITLE
Add support for X-Forwarded-Prefix

### DIFF
--- a/frontend/src/kuberos.vue
+++ b/frontend/src/kuberos.vue
@@ -72,7 +72,7 @@ export default {
   },
   methods: {
     templateURL: function() {
-      return "/kubecfg.yaml?" + $.param(this.kubecfg);
+      return "kubecfg.yaml?" + $.param(this.kubecfg);
     },
     snippetSetCreds: function() {
       return (
@@ -114,7 +114,7 @@ export default {
     if (q != "") {
       query = JSON.parse('{"' + q + '"}');
     }
-    var url = "/kubecfg?" + $.param(query);
+    var url = "kubecfg?" + $.param(query);
 
     var _this = this;
     this.axios


### PR DESCRIPTION
This PR adds support for X-Forwarded-Prefix header that is added by some proxies when manipulating the path of requests (example https://docs.traefik.io/basics/#matchers).

This should allow to run Kuberos behind a proxy with a path manipulaiton for instance: example.com/kuberos/ with the callback example.com/kuberos/ui

Where currently hosting Kuberos at example.com/kuberos/ the callback passed to OIDC is example.com/ui

I'm open to any other ideas on how to tackle this.