### PR TITLE
Set a default user

### DIFF
--- a/frontend/src/kuberos.vue
+++ b/frontend/src/kuberos.vue
@@ -121,6 +121,9 @@ export default {
       .get(url)
       .then(function(response) {
         _this.kubecfg = response.data;
+        if(_this.kubecfg.email == "") {
+          _this.kubecfg.email = "kuberos";
+        }
       })
       .catch(function(error) {
         _this.error = error;


### PR DESCRIPTION
Since the *email* claim is not a required part of the OpenID spec, I suggest to set a default value for cases where it is not available. If the OpenID provider does not provide an email claim or it is empty, this provides a graceful fallback.

I have tested it locally and it will generate something like
```
kubectl config set-credentials "default-user" \
...
kubectl config set-context ${CONTEXT} --cluster ${CLUSTER} --user="default-user"
```
which works for kubectl (but "" would not)