### PR TITLE
Use minimal OpenID scope

### DIFF
--- a/cmd/kuberos/kuberos.go
+++ b/cmd/kuberos/kuberos.go
@@ -46,7 +46,7 @@ func main() {
 		app         = kingpin.New(filepath.Base(os.Args[0]), "Provides OIDC authentication configuration for kubectl.").DefaultEnvars()
 		listen      = app.Flag("listen", "Address at which to expose HTTP webhook.").Default(":10003").String()
 		debug       = app.Flag("debug", "Run with debug logging.").Short('d').Bool()
-		extraScopes = app.Flag("extra-scopes", "List of additional scopes to provide in token.").Strings()
+		extraScopes = app.Flag("scopes", "List of additional scopes to provide in token.").Default("profile", "email").Strings()
 		grace       = app.Flag("shutdown-grace-period", "Wait this long for sessions to end before shutting down.").Default("1m").Duration()
 
 		issuerURL        = app.Arg("oidc-issuer-url", "OpenID Connect issuer URL.").URL()

--- a/kuberos.go
+++ b/kuberos.go
@@ -49,7 +49,7 @@ const (
 var (
 	// DefaultScopes are the minimum required oauth2 scopes for every
 	// authentication request.
-	DefaultScopes = []string{oidc.ScopeOpenID, "profile", "email"}
+	DefaultScopes = []string{oidc.ScopeOpenID}
 
 	// ErrInvalidKubeCfgEndpoint indicates an unparseable redirect endpoint.
 	ErrInvalidKubeCfgEndpoint = errors.New("invalid redirect endpoint")

--- a/kuberos_test.go
+++ b/kuberos_test.go
@@ -41,7 +41,7 @@ func TestAuthCodeURL(t *testing.T) {
 				RedirectURL:  "https://example.org/redirect",
 			},
 			s:   func(_ *http.Request) string { return "state" },
-			url: "https://auth.example.org?access_type=offline&client_id=testClientID&prompt=consent&redirect_uri=http%3A%2F%2Fexample.com%2Fui&response_type=code&scope=openid+profile+email&state=state",
+			url: "https://auth.example.org?access_type=offline&client_id=testClientID&prompt=consent&redirect_uri=http%3A%2F%2Fexample.com%2Fui&response_type=code&scope=openid&state=state",
 		},
 		{
 			name: "CustomScopes",


### PR DESCRIPTION
The *email* and *profile* scopes are optional in the OpenID spec, therefore it would increase compatibility to not include them in the DefaultScopes. They can always be re-added with `--extra-scopes` where necessary.

I have tested this with GitLab as an OpenID Provider, which does not support the profile or email scopes.

This works best with #28 