### PR TITLE
Use multi-staging Dockerfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,9 @@ jobs:
     - stage: push
       install: skip
       script:
-        - ./scripts/build.sh
+        - VERSION=$(git rev-parse --short HEAD)
+        - docker build --tag "negz/kuberos:latest" .
+        - docker build --tag "negz/kuberos:${VERSION}" .
         - docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
         - ./scripts/push.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN go get -u github.com/Masterminds/glide && \
 RUN cd statik && go generate && cd ..
 RUN go build -o /kuberos ./cmd/kuberos
 
-FROM alpine:3.7 as ca-certificates
+FROM alpine:3.7
 MAINTAINER Nic Cope <n+docker@rk0n.org>
 
 RUN apk --no-cache add ca-certificates

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,25 @@
-FROM alpine:3.7
+FROM node:9.8-alpine as node
+ADD frontend/ .
+RUN npm install && npm run build
+
+FROM golang:1.10-alpine as golang
+RUN apk --no-cache add git
+WORKDIR /go/src/github.com/negz/kuberos/
+ENV CGO_ENABLED=0
+
+ADD . .
+COPY --from=node dist/ dist/frontend
+COPY --from=node index.html dist/frontend/
+
+RUN go get -u github.com/Masterminds/glide && \
+  go get -u github.com/rakyll/statik && \
+  glide install
+
+RUN cd statik && go generate && cd ..
+RUN go build -o /kuberos ./cmd/kuberos
+
+FROM alpine:3.7 as ca-certificates
 MAINTAINER Nic Cope <n+docker@rk0n.org>
 
-RUN apk update && apk add ca-certificates
-
-COPY "dist/kuberos" /
+RUN apk --no-cache add ca-certificates
+COPY --from=golang /kuberos /


### PR DESCRIPTION
Since I ran into some problems to make get the scripts/build.sh working locally, I made this multi-stage Dockerfile to make it portable and easy to reproduce. A `docker build .` will compile frontend, backend and will result in a working docker image.

I also took the opportunity to update the resulting image to use *scratch* as a base to keep it compact and finally to add `/kuberos` as an `ENTRYPOINT` so it you don't need to specify `/kuberos` for each `docker run`

Let me know what you think.