### PR TITLE
Added email-domain flag to restrict access to given domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,22 +65,21 @@ usage: kuberos [<flags>] [<oidc-issuer-url>] [<client-id>] [<client-secret-file>
 Provides OIDC authentication configuration for kubectl.
 
 Flags:
-      --help             Show context-sensitive help (also try --help-long and
-                         --help-man).
+      --help             Show context-sensitive help (also try --help-long and --help-man).
       --listen=":10003"  Address at which to expose HTTP webhook.
   -d, --debug            Run with debug logging.
+      --extra-scopes=EXTRA-SCOPES ...
+                         List of additional scopes to provide in token.
       --shutdown-grace-period=1m
-                         Wait this long for sessions to end before shutting
-                         down.
-      --email-domain     Restrict access to users with emails that match
-                         this domain
+                         Wait this long for sessions to end before shutting down.
+      --email-domain=EMAIL-DOMAIN
+                         The eamil domain to restrict access to.
 
 Args:
   [<oidc-issuer-url>]     OpenID Connect issuer URL.
   [<client-id>]           OAuth2 client ID.
   [<client-secret-file>]  File containing OAuth2 client secret.
-  [<kubecfg-template>]    A kubecfg file containing clusters to populate with a
-                          user and contexts.
+  [<kubecfg-template>]    A kubecfg file containing clusters to populate with a user and contexts.
 ```
 
 The partial `kubeconfig` template should contain only cluster entries and

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Flags:
       --shutdown-grace-period=1m
                          Wait this long for sessions to end before shutting
                          down.
+      --email-domain     Restrict access to users with emails that match
+                         this domain
 
 Args:
   [<oidc-issuer-url>]     OpenID Connect issuer URL.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Flags:
       --shutdown-grace-period=1m
                          Wait this long for sessions to end before shutting down.
       --email-domain=EMAIL-DOMAIN
-                         The eamil domain to restrict access to.
+                         The email domain to restrict access to.
 
 Args:
   [<oidc-issuer-url>]     OpenID Connect issuer URL.

--- a/cmd/kuberos/kuberos.go
+++ b/cmd/kuberos/kuberos.go
@@ -43,10 +43,11 @@ func logRequests(h http.Handler, log *zap.Logger) http.Handler {
 
 func main() {
 	var (
-		app    = kingpin.New(filepath.Base(os.Args[0]), "Provides OIDC authentication configuration for kubectl.").DefaultEnvars()
-		listen = app.Flag("listen", "Address at which to expose HTTP webhook.").Default(":10003").String()
-		debug  = app.Flag("debug", "Run with debug logging.").Short('d').Bool()
-		scopes = app.Flag("scopes", "List of additional scopes to provide in token.").Default("profile", "email").Strings()
+		app         = kingpin.New(filepath.Base(os.Args[0]), "Provides OIDC authentication configuration for kubectl.").DefaultEnvars()
+		listen      = app.Flag("listen", "Address at which to expose HTTP webhook.").Default(":10003").String()
+		debug       = app.Flag("debug", "Run with debug logging.").Short('d').Bool()
+		scopes      = app.Flag("scopes", "List of additional scopes to provide in token.").Default("profile", "email").Strings()
+		emailDomain = app.Flag("email-domain", "The eamil domain to restrict access to.").String()
 
 		grace            = app.Flag("shutdown-grace-period", "Wait this long for sessions to end before shutting down.").Default("1m").Duration()
 		shutdownEndpoint = app.Flag("shutdown-endpoint", "Insecure HTTP endpoint path (e.g., /quitquitquit) that responds to a GET to shut down kuberos.").String()
@@ -81,7 +82,7 @@ func main() {
 		Endpoint:     provider.Endpoint(),
 		Scopes:       sr.Get(),
 	}
-	e, err := extractor.NewOIDC(provider.Verifier(&oidc.Config{ClientID: *clientID}), extractor.Logger(log))
+	e, err := extractor.NewOIDC(provider.Verifier(&oidc.Config{ClientID: *clientID}), *emailDomain, extractor.Logger(log))
 	kingpin.FatalIfError(err, "cannot setup OIDC extractor")
 
 	h, err := kuberos.NewHandlers(cfg, e, kuberos.Logger(log))

--- a/cmd/kuberos/kuberos.go
+++ b/cmd/kuberos/kuberos.go
@@ -82,7 +82,7 @@ func main() {
 		Endpoint:     provider.Endpoint(),
 		Scopes:       sr.Get(),
 	}
-	e, err := extractor.NewOIDC(provider.Verifier(&oidc.Config{ClientID: *clientID}), *emailDomain, extractor.Logger(log))
+	e, err := extractor.NewOIDC(provider.Verifier(&oidc.Config{ClientID: *clientID}), extractor.Logger(log), extractor.EmailDomain(*emailDomain))
 	kingpin.FatalIfError(err, "cannot setup OIDC extractor")
 
 	h, err := kuberos.NewHandlers(cfg, e, kuberos.Logger(log))

--- a/extractor/oidc.go
+++ b/extractor/oidc.go
@@ -69,13 +69,13 @@ func EmailDomain(domain string) Option {
 }
 
 // NewOIDC creates a new OIDC extractor.
-func NewOIDC(v *oidc.IDTokenVerifier, oo ...Option) (OIDC, error) {
+func NewOIDC(v *oidc.IDTokenVerifier, emailDomain string, oo ...Option) (OIDC, error) {
 	l, err := zap.NewProduction()
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot create default logger")
 	}
 
-	oe := &oidcExtractor{log: l, v: v, h: http.DefaultClient}
+	oe := &oidcExtractor{log: l, v: v, h: http.DefaultClient, emailDomain: emailDomain}
 
 	for _, o := range oo {
 		if err := o(oe); err != nil {

--- a/extractor/oidc.go
+++ b/extractor/oidc.go
@@ -69,13 +69,13 @@ func EmailDomain(domain string) Option {
 }
 
 // NewOIDC creates a new OIDC extractor.
-func NewOIDC(v *oidc.IDTokenVerifier, emailDomain string, oo ...Option) (OIDC, error) {
+func NewOIDC(v *oidc.IDTokenVerifier, oo ...Option) (OIDC, error) {
 	l, err := zap.NewProduction()
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot create default logger")
 	}
 
-	oe := &oidcExtractor{log: l, v: v, h: http.DefaultClient, emailDomain: emailDomain}
+	oe := &oidcExtractor{log: l, v: v, h: http.DefaultClient}
 
 	for _, o := range oo {
 		if err := o(oe); err != nil {


### PR DESCRIPTION
Specifying the --email-domain flag allows you to prevent users with emails that don't match the given domain from accessing your secrets. This allows you to more confidently and securely expose kuberos to the internet

This is my first time writing go so please excuse any obvious mistakes. Happy to accept/implement feedback