### PR TITLE
Add cluster CA certificate into kubeconfig if one exists

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 586f06dac64626a980055d13a01b7e19966239a07ac7a1bdffd61c52b1e33219
-updated: 2018-01-16T15:48:55.20164-08:00
+hash: 76fa71a7a967d86b98a17d084d6ff4a1a572f96418730d4fad33c82ff5d282cc
+updated: 2018-05-16T01:07:31.651399512-07:00
 imports:
 - name: github.com/alecthomas/template
   version: a0175ee3bccc567396460bf5acd36800cb10c49c
@@ -80,6 +80,10 @@ imports:
   version: fd36b3595eb2ec8da4b8153b107f7ea08504899d
   subpackages:
   - fs
+- name: github.com/spf13/afero
+  version: 63644898a8da0bc22138abf860edaf5277b6102e
+  subpackages:
+  - mem
 - name: github.com/spf13/pflag
   version: 9ff6c6923cfffbcd502984b8e0c80539a94968b7
 - name: go.uber.org/atomic

--- a/glide.yaml
+++ b/glide.yaml
@@ -20,6 +20,8 @@ import:
   subpackages:
   - tools/clientcmd
   - tools/clientcmd/api
+- package: github.com/spf13/afero
+  version: ^1.1.0
 testImport:
 - package: github.com/go-test/deep
   version: v1.0.0

--- a/kuberos_test.go
+++ b/kuberos_test.go
@@ -125,6 +125,7 @@ func TestPopulateUser(t *testing.T) {
 						},
 					},
 				},
+				CurrentContext: "a",
 			},
 		},
 		{


### PR DESCRIPTION
Addresses one of the ideas in #31. Instead of adding YAML templating, this PR takes a different approach:

1. Check each cluster definition (`clusters[*].cluster` in the kubeconfig) to see if either `certificate-authority-data` (binary embedded PEM data) or `certificate-authority` (path to client-side file) are non-empty in the template.
  a. If both certificate fields are empty and `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt` is accessible by Kuberos (which only happens when Kuberos is run in-cluster, and its pod is given a service account), then the contents of ca.crt is used as the value of `certificate-authority-data`.
  b. Otherwise, no behavior changes.
2. If the template already has a `current-context`, it's still used as the default. Otherwise, `current-context` is set to the first non-empty context.

I'd love feedback overall, but two things jumped out in particular:

3. I'm not sure what the best way to add tests for (1) above, since it needs to test filesystem access. 
4. I added `DefaultAPITokenMountPath`, because there doesn't seem to be an easy way to access the definition of it without pulling in the entirety of `k8s.io/kubernetes/plugin/pkg/admission/serviceaccount`.
