### PR TITLE
Add alternative OIDC helper: dex-k8s-authenticator

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,9 @@ data:
 ```
 
 ## Alternatives
+OIDC/LDAP/static helper specifically for `dex` (Helm charts for dex+helper included)
+* https://github.com/mintel/dex-k8s-authenticator
+
 OIDC helpers that run locally to setup `kubectl`:
 * https://github.com/micahhausler/k8s-oidc-helper
 * https://github.com/coreos/dex/tree/master/cmd/example-app


### PR DESCRIPTION
This project already links to Kuberos as an alternative. Seems similar except `dex-k8s-authenticator` specifically targets `dex`, and the web UI supports all `dex` auth methods, OIDC, LDAP, static.